### PR TITLE
Limit Serializers for Interest and Activity to 'name' and 'id'

### DIFF
--- a/apps/timeplace/serializers.py
+++ b/apps/timeplace/serializers.py
@@ -9,13 +9,13 @@ from . import models
 class InterestModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Interest
-        fields = "__all__"
+        fields = ["id","name"]
 
 
 class ActivityModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Activity
-        fields = "__all__"
+        fields = ["id","name"]
 
 
 class TimePlaceModelCreateUpdateSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
We don't need to see creation date or modified date for this models, as we don't want users to modify them anyway.