### PR TITLE
Don't filter the queryset by user_id if user is superuser

### DIFF
--- a/apps/timeplace/views.py
+++ b/apps/timeplace/views.py
@@ -56,4 +56,6 @@ class TimePlaceViewSet(viewsets.ModelViewSet):
         """Limit the queryset to the author, 
         i.e the logged in user, for fetching/updating data
         """
+        if self.request.user.is_superuser:
+            return self.queryset
         return self.queryset.filter(user_id=self.request.user)


### PR DESCRIPTION
The superuser should see timeplaces from all users and not just its own.