### PR TITLE
Enables the default queryset for UserProfileModelViewSet

### DIFF
--- a/apps/user/views.py
+++ b/apps/user/views.py
@@ -49,7 +49,7 @@ class ListUsers(viewsets.ModelViewSet):
 
 
 class UserProfileModelViewSet(viewsets.ModelViewSet):
-    # queryset = UserProfile.objects.all()
+    queryset = UserProfile.objects.all()
     permission_classes = (
         IsAuthenticatedCreateOrSuperOrAuthor,
     )


### PR DESCRIPTION
See title. Uncomments the de-activated line in views.py to have a default queryset.