### PR TITLE
Add CORS headers so swagger can work with the dev server

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -22,6 +22,7 @@ CUSTOM_APPS = [
 THIRD_PARTY_APPS = [
     "rest_framework",
     "rest_framework.authtoken",
+    "corsheaders",
 ]
 
 INSTALLED_APPS = [*DEFAULT_APPS, *CUSTOM_APPS, *THIRD_PARTY_APPS]
@@ -31,6 +32,7 @@ AUTHENTICATION_BACKENDS = ['apps.user.backends.EmailOrUsernameModelBackend']
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -53,3 +53,5 @@ SPECTACULAR_SETTINGS = {
     # e.g. [{'url': 'https://example.com/v1', 'description': 'Text'}, ...]
     'SERVERS': [{'url': 'http://localhost:8000/', 'description': 'Local Dev Server'},],
 }
+
+CORS_ALLOW_ALL_ORIGINS = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,3 +3,4 @@ djangorestframework==3.14.0
 psycopg2==2.9.9
 python-environ==0.4.54
 geopy==2.4.0
+django-cors-headers==4.3.1


### PR DESCRIPTION
We have to remember to set https://github.com/adamchainz/django-cors-headers#configuration in the `prod.py` settings when the time comes.