### PR TITLE
Minor cleanup - return None instead of 'Hidden', different serializer for TimePlace Post response

### DIFF
--- a/apps/match/serializers.py
+++ b/apps/match/serializers.py
@@ -47,8 +47,8 @@ from . import models
                         }
                         ]
                     },
-                    "foreign_email": "Hidden",
-                    "foreign_phone": "Hidden",
+                    "foreign_email": None,
+                    "foreign_phone": None,
                     "chat_accepted": False
                     },
         ),
@@ -96,11 +96,11 @@ class MatchModelListRetrieveSerializer(serializers.ModelSerializer):
             if obj.email_user_2:
                 return obj.timeplace_2.user.userprofile.profile_email
             else:
-                return "Hidden"
+                return None
         if obj.email_user_1:
             return obj.timeplace_1.user.userprofile.profile_email
         else:
-            return "Hidden"
+            return None
 
     @extend_schema_field(OpenApiTypes.STR)    
     def get_foreign_phone(self, obj):
@@ -110,11 +110,11 @@ class MatchModelListRetrieveSerializer(serializers.ModelSerializer):
             if obj.phone_user_2:
                 return obj.timeplace_2.user.userprofile.phone
             else:
-                return "Hidden"
+                return None
         if obj.phone_user_1:
             return obj.timeplace_1.user.userprofile.phone
         else:
-            return "Hidden"
+            return None
 
 
 class MatchChatModelSerializer(serializers.ModelSerializer):

--- a/apps/match/tests/ut/test_match_endpoints.py
+++ b/apps/match/tests/ut/test_match_endpoints.py
@@ -171,14 +171,14 @@ class TestMatchEndpoints(APITestCase):
         url = reverse('match-detail', kwargs={'pk': self.user1.id})
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user2token.key)
         response = self.client.get(url)
-        self.assertEqual(response.data['foreign_phone'], 'Hidden')
+        self.assertEqual(response.data['foreign_phone'], None)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
     def test_foreign_user_email_is_hidden(self):
         url = reverse('match-detail', kwargs={'pk': self.user1.id})
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user2token.key)
         response = self.client.get(url)
-        self.assertTrue(response.data['foreign_email'], 'Hidden')
+        self.assertEqual(response.data['foreign_email'], None)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         
     def test_chat_accepted_for_users(self):

--- a/apps/timeplace/serializers.py
+++ b/apps/timeplace/serializers.py
@@ -66,6 +66,9 @@ class TimePlaceModelCreateSerializer(serializers.ModelSerializer):
             validated_data['latitude'], validated_data['longitude'])
         return super(TimePlaceModelCreateSerializer, self).create(validated_data)
 
+    def to_representation(self, instance):
+        return (TimePlaceModelViewSerializer(context=self.context)
+                .to_representation(instance))
 
 class TimePlaceModelUpdateSerializer(serializers.ModelSerializer):
     """Serializer to update a TimePlace model instance that takes interests 

--- a/apps/timeplace/views.py
+++ b/apps/timeplace/views.py
@@ -8,7 +8,7 @@ from rest_framework import serializers as drf_serializers
 from rest_framework.response import Response
 from rest_framework.decorators import action
 from geopy.distance import distance
-from drf_spectacular.utils import extend_schema, inline_serializer
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 from drf_spectacular.utils import OpenApiParameter, OpenApiTypes, OpenApiResponse
 
 from apps.match.models import Match
@@ -30,6 +30,15 @@ class ActivityViewSet(viewsets.ModelViewSet):
 
     serializer_class = serializers.ActivityModelSerializer
 
+
+@extend_schema_view(
+    create=extend_schema(
+        description="""Create a new TimePlace.
+        Latitude and Longitude are numbers with up to six decimal places.
+        Latitude needs to be between -90 and 90.
+        Longitude needs to be between -180 and 180.""",
+        request=serializers.TimePlaceModelCreateSerializer,
+        responses={201: serializers.TimePlaceModelViewSerializer}))
 class TimePlaceViewSet(viewsets.ModelViewSet):
     permission_classes = (permissions.IsAuthenticatedCreateOrSuperOrAuthor,)
 

--- a/schema.yml
+++ b/schema.yml
@@ -520,8 +520,8 @@ paths:
                         activities:
                         - id: 1
                           name: Visiting a Museum
-                      foreign_email: Hidden
-                      foreign_phone: Hidden
+                      foreign_email: null
+                      foreign_phone: null
                       chat_accepted: false
                   summary: Example for a match object
           description: ''
@@ -570,8 +570,8 @@ paths:
                       activities:
                       - id: 1
                         name: Visiting a Museum
-                    foreign_email: Hidden
-                    foreign_phone: Hidden
+                    foreign_email: null
+                    foreign_phone: null
                     chat_accepted: false
                   summary: Example for a match object
           description: ''
@@ -637,15 +637,15 @@ paths:
                       activities:
                       - id: 1
                         name: Visiting a Museum
-                    foreign_email: Hidden
-                    foreign_phone: Hidden
+                    foreign_email: null
+                    foreign_phone: null
                     chat_accepted: false
                   summary: Example for a match object
           description: ''
   /api/v1/match/{id}/share_email/:
     post:
       operationId: match_share_email_create
-      description: API endpoint that allows matches to be viewed or edited.
+      description: Set the email_user_x field to True for the user of the request.
       parameters:
       - in: path
         name: id
@@ -665,7 +665,7 @@ paths:
   /api/v1/match/{id}/share_phone/:
     post:
       operationId: match_share_phone_create
-      description: API endpoint that allows matches to be viewed or edited.
+      description: Set the phone_user_x field to True for the user of the request.
       parameters:
       - in: path
         name: id
@@ -705,6 +705,11 @@ paths:
           description: ''
     post:
       operationId: timeplace_create
+      description: |-
+        Create a new TimePlace.
+                Latitude and Longitude are numbers with up to six decimal places.
+                Latitude needs to be between -90 and 90.
+                Longitude needs to be between -180 and 180.
       tags:
       - timeplace
       requestBody:
@@ -726,7 +731,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TimePlaceModelCreate'
+                $ref: '#/components/schemas/TimePlaceModelView'
           description: ''
   /api/v1/timeplace/{id}/:
     get:
@@ -1810,56 +1815,6 @@ components:
       - id
       - interests
       - user
-    TimePlaceModelCreate:
-      type: object
-      description: |-
-        Serializer to create a TimePlace model instance that takes interests
-        and activities as a list of integers and does not include the user.
-        Automatically fills the city field with the nearest city to the given
-        coordinates in a radius of 100 miles.
-      properties:
-        id:
-          type: integer
-          readOnly: true
-        start:
-          type: string
-          format: date-time
-        end:
-          type: string
-          format: date-time
-        latitude:
-          type: string
-          format: decimal
-          pattern: ^-?\d{0,3}(?:\.\d{0,6})?$
-        longitude:
-          type: string
-          format: decimal
-          pattern: ^-?\d{0,3}(?:\.\d{0,6})?$
-        radius:
-          type: integer
-          maximum: 32767
-          minimum: 0
-        description:
-          type: string
-          maxLength: 500
-        interests:
-          type: array
-          items:
-            type: integer
-        activities:
-          type: array
-          items:
-            type: integer
-      required:
-      - activities
-      - description
-      - end
-      - id
-      - interests
-      - latitude
-      - longitude
-      - radius
-      - start
     TimePlaceModelCreateRequest:
       type: object
       description: |-


### PR DESCRIPTION
I've cleaned up some open items:
- The match now returns None/null instead of 'Hidden' if the other user hasn't agreed to share his contact information yet.
- The TimePlace Viewset now returns a response with the TimePlaceModelViewSerializer, so we can immediately see the selected interests and the automatically determined city.
- Some more documentation for the OpenAPI schema to clarify the expected values for latitude and longitude