### PR TITLE
Overhaul readme and prevent missing RAPID_API key to crash whole application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,68 @@
-# Linc Local Backend
+# SameTimeSamePlace Backend
 
-> “The beginning of wisdom is to call things by their proper name.” ― Confucius
+Welcome to the SameTimeSamePlace Backend project! Our goal is to bring people together who want to experience new things and get to know new people at the same time.
 
+## How to run
 
-## How to get on board
-
-1. Create a Python v3.11 virtual environment (and start it)
-
-* `$ python3.11 -m venv .venv --prompt DjangoApp`
-
-* `$ source .venv/bin/activate`
-
-2. Install all required packages
-
-* `$ pip install -r requirements/dev.txt`
-
-3. Create your own .env file that corresponds to /settings/dev.py
-
+### Preparations
+#### .env file
+This project uses Django and PostgreSQL. Make sure you have a PostgreSQL-server running.
+To run the project, clone the repo and create a `.env` file in the root folder containing:
 ```
-DB_NAME=<name-of-database>
-DB_HOST=localhost
-DB_PORT=5432
-DB_USER=<your-db-username>
-DB_PASSWORD=<your-db-password>
-DB_SECRET=<the-django-secret-key>
+DB_HOST=<address of your postgresql server>
+DB_NAME=<name of the database you want to use>
+DB_USER=<postgres-username>
+DB_PASSWORD=<postgres-user-password>
+DB_PORT=<port to connect to your server, default is 5432>
+DB_SECRET=<secret token>
+RAPID_API=<your geodb api token>
+```
+To obtain the `RAPID_API` key, you can subscribe to the [GeoDB Cities API on RapidAPI](https://rapidapi.com/wirefreethought/api/geodb-cities). Leaving the value empty will still allow the project to work, but the city information of newly created timeplaces won't be automatically filled.
+
+To create a new secret token, you can import `secrets` in python and use `secrets.token_urlsafe(<bytes>)`. It's common to precede `django-insecure` for dev environments.
+
+#### Python environment
+Create a virtual python environment with the tool of your choice, for example `venv`:
+```bash
+python -m venv .venv
+```
+And activate it with 
+```bash
+source .venv/bin/activate
 ```
 
-4. Committing migrations for database modification
+Next, install the required modules with pip:
+```bash
+pip install -r requirements/dev.txt
+```
 
-* `$ make dev-makemigrations`
+For convenience, the `Makefile` includes several targets - for this case, you can use 
+```bash
+make dev-install
+```
+ to install the dependencies.
 
-5. Apply migrations to the database
+#### Migrating the models to the database
+To populate your database with the required tables and relations, run 
+```bash
+make dev-makemigrations
+```
+followed by 
+```bash
+dev-migrate
+```
 
-* `$ make dev-migrate`
+#### Create an admin user
+To create an admin user, you can use 
+```bash
+python manage.py createsuperuser --settings=config.settings.dev
+```
 
-6. Start Django server
+### Starting the server
+You should now be able to start the django server with 
+```bash
+make dev-start
+```
+and access the site on [http://127.0.0.1:8000/](http://127.0.0.1:8000/).
 
-* `$ make dev-start`
+The Swagger API documentation is available on [http://127.0.0.1:8000/api/v1/swagger](http://127.0.0.1:8000/api/v1/swagger)

--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -3,6 +3,8 @@ import json
 from http import client
 from pathlib import Path
 
+from django.core.exceptions import ImproperlyConfigured
+
 
 class MetaSingleton(type):
     """Metaclass to create singleton classes.
@@ -28,7 +30,10 @@ def get_nearest_city(lat: float, long: float) -> str:
     env = environ.Env()
     environ.Env.read_env(str(BASE_DIR / ".env"))
 
-    RAPID_API = env.str("RAPID_API")
+    try:
+        RAPID_API = env.str("RAPID_API")
+    except ImproperlyConfigured:
+        RAPID_API = "no_key_found"
 
     conn = client.HTTPSConnection("wft-geo-db.p.rapidapi.com", timeout=2)
     

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -40,7 +40,7 @@ REST_FRAMEWORK['PAGE_SIZE'] = 50
 SPECTACULAR_SETTINGS = {
     'TITLE': 'SameTimeSamePlace API',
     'DESCRIPTION': 'Find friends for an adventure.',
-    'VERSION': '0.1.0',
+    'VERSION': '0.2.0',
     'SERVE_INCLUDE_SCHEMA': False,
     # Split components into request and response parts where appropriate
     'COMPONENT_SPLIT_REQUEST': True,

--- a/schema.yml
+++ b/schema.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: SameTimeSamePlace API
-  version: 0.1.0
+  version: 0.2.0
   description: Find friends for an adventure.
 paths:
   /api/v1/activity/:
@@ -645,7 +645,7 @@ paths:
   /api/v1/match/{id}/share_email/:
     post:
       operationId: match_share_email_create
-      description: API endpoint that allows matches to be viewed or edited.
+      description: Set the email_user_x field to True for the user of the request.
       parameters:
       - in: path
         name: id
@@ -665,7 +665,7 @@ paths:
   /api/v1/match/{id}/share_phone/:
     post:
       operationId: match_share_phone_create
-      description: API endpoint that allows matches to be viewed or edited.
+      description: Set the phone_user_x field to True for the user of the request.
       parameters:
       - in: path
         name: id


### PR DESCRIPTION
With this, the server should no longer crash if no `RAPID_API` entry is found in the .env file.
