### PR TITLE
Prevent creation of matches between timeplaces of the same user

### DIFF
--- a/apps/timeplace/tests/ut/test_matching_endpoint.py
+++ b/apps/timeplace/tests/ut/test_matching_endpoint.py
@@ -427,3 +427,13 @@ class TestInterestEndpoints(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user3token.key)
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_match_for_same_user(self):
+        """Test if a match object can be created for timeplaces of the same user
+        """
+        url = reverse("timeplace-get-match", args=(self.user1_tp1.id,
+                                                   self.user1_tp2.id))
+        # Test if a user can create a match between his own timeplaces
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.user1token.key)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/timeplace/views.py
+++ b/apps/timeplace/views.py
@@ -212,6 +212,12 @@ class TimePlaceViewSet(viewsets.ModelViewSet):
         own_tp = self.get_object()
         other_tp = models.TimePlace.objects.get(pk=timeplace_pk)
 
+        if own_tp.user == other_tp.user:
+            return Response(
+                {"error": "Can't match with same user"},
+                status=status.HTTP_403_FORBIDDEN
+            )
+
         # Check if a match between the two timeplaces already exists
         queryset = Match.objects.filter(
             (Q(timeplace_1=own_tp) | Q(timeplace_1=other_tp)) &


### PR DESCRIPTION
This solves https://github.com/sametimesameplace/backend/issues/69
A user should not be able to create a match between two of his own timeplaces.